### PR TITLE
Fix bugs and centralize API config

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,6 @@
+export const API_BASE_URL = 'http://localhost:3001';
+
+export const SNEAKERS_URL = `${API_BASE_URL}/sneakers`;
+export const CART_ITEMS_URL = `${API_BASE_URL}/cartItems`;
+export const FAVORITES_URL = `${API_BASE_URL}/favorites`;
+export const ORDERS_URL = `${API_BASE_URL}/orders`;

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { Context } from "../../context/Context.js";
 import axios from "axios";
+import {
+  SNEAKERS_URL,
+  CART_ITEMS_URL,
+  FAVORITES_URL,
+  ORDERS_URL,
+} from "../../api";
 import "./App.css";
 import Header from "../Header/Header.js";
 import Drawer from "../Drawer/Drawer.js";
@@ -22,10 +28,6 @@ function App() {
   const [isOrdersLoading, setIsOrdersLoading] = useState(true);
   const [isAdded, setIsAdded] = useState(false);
 
-  const SNEAKERS_URL = "http://localhost:3001/sneakers";
-  const CART_ITEMS_URL = "http://localhost:3001/cartItems";
-  const FAVORITES_URL = "http://localhost:3001/favorites";
-  const ORDERS_URL = "http://localhost:3001/orders";
 
   const totalPrice = cartItems.reduce((sum, obj) => obj.price + sum, 0);
   const cartItemsQuantity = cartItems.length;
@@ -34,40 +36,52 @@ function App() {
   const navigate = useNavigate();
   const goBack = () => navigate(-1);
 
-  const getSneakersCards = () => {
-    axios
-      .get(SNEAKERS_URL)
-      .then((res) => setCards(res.data))
-      .catch((err) => console.log(err))
-      .finally(() => setIsCardsLoading(false));
+  const getSneakersCards = async () => {
+    try {
+      const { data } = await axios.get(SNEAKERS_URL);
+      setCards(data);
+    } catch (err) {
+      alert("Не удалось загрузить список кроссовок");
+      console.log(err);
+    } finally {
+      setIsCardsLoading(false);
+    }
   };
 
-  const getCartItems = () => {
-    axios
-      .get(CART_ITEMS_URL)
-      .then((res) => setCartItems(res.data))
-      .catch((err) => console.log(err))
-      .finally(() => setIsCartItemsLoading(false));
+  const getCartItems = async () => {
+    try {
+      const { data } = await axios.get(CART_ITEMS_URL);
+      setCartItems(data);
+    } catch (err) {
+      alert("Ошибка при загрузке корзины");
+      console.log(err);
+    } finally {
+      setIsCartItemsLoading(false);
+    }
   };
 
-  const getFavorites = () => {
-    axios
-      .get(FAVORITES_URL)
-      .then((res) => setFavorites(res.data))
-      .catch((err) => console.log(err))
-      .finally(() => {
-        setIsFavoritesLoading(false);
-      });
+  const getFavorites = async () => {
+    try {
+      const { data } = await axios.get(FAVORITES_URL);
+      setFavorites(data);
+    } catch (err) {
+      alert("Ошибка при загрузке избранного");
+      console.log(err);
+    } finally {
+      setIsFavoritesLoading(false);
+    }
   };
 
-  const getOrders = () => {
-    axios
-      .get(ORDERS_URL)
-      .then((res) => setOrders(res.data))
-      .catch((err) => console.log(err))
-      .finally(() => {
-        setIsOrdersLoading(false);
-      });
+  const getOrders = async () => {
+    try {
+      const { data } = await axios.get(ORDERS_URL);
+      setOrders(data);
+    } catch (err) {
+      alert("Ошибка при загрузке заказов");
+      console.log(err);
+    } finally {
+      setIsOrdersLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -85,32 +99,52 @@ function App() {
     setDrawerOpen(false);
   };
 
-  const onAddToCart = (sneaker) => {
+  const onAddToCart = async (sneaker) => {
     const existingCartItem = cartItems.find((item) => item.id === sneaker.id);
     if (!existingCartItem) {
-      setCartItems([...cartItems, sneaker]);
-      axios.post(CART_ITEMS_URL, sneaker);
+      try {
+        setCartItems([...cartItems, sneaker]);
+        await axios.post(CART_ITEMS_URL, sneaker);
+      } catch (err) {
+        alert("Не удалось добавить в корзину");
+        console.log(err);
+      }
     }
   };
 
-  const onRemoveItem = (id) => {
-    axios.delete(`${CART_ITEMS_URL}/${id}`);
-    setCartItems(cartItems.filter((item) => item.id !== id));
+  const onRemoveItem = async (id) => {
+    try {
+      await axios.delete(`${CART_ITEMS_URL}/${id}`);
+      setCartItems(cartItems.filter((item) => item.id !== id));
+    } catch (err) {
+      alert("Не удалось удалить товар из корзины");
+      console.log(err);
+    }
   };
 
-  const onAddToFavorite = (sneaker) => {
+  const onAddToFavorite = async (sneaker) => {
     const existingFavoriteItem = favorites.find(
       (item) => item.id === sneaker.id
     );
     if (!existingFavoriteItem) {
-      setFavorites([...favorites, sneaker]);
-      axios.post(FAVORITES_URL, sneaker);
+      try {
+        setFavorites([...favorites, sneaker]);
+        await axios.post(FAVORITES_URL, sneaker);
+      } catch (err) {
+        alert("Не удалось добавить в избранное");
+        console.log(err);
+      }
     }
   };
 
-  const onRemoveFavorite = (id) => {
-    axios.delete(`${FAVORITES_URL}/${id}`);
-    setFavorites(favorites.filter((item) => item.id !== id));
+  const onRemoveFavorite = async (id) => {
+    try {
+      await axios.delete(`${FAVORITES_URL}/${id}`);
+      setFavorites(favorites.filter((item) => item.id !== id));
+    } catch (err) {
+      alert("Не удалось удалить из избранного");
+      console.log(err);
+    }
   };
 
   return (

--- a/src/components/Cards/Cards.js
+++ b/src/components/Cards/Cards.js
@@ -10,6 +10,7 @@ import { useLocation } from "react-router-dom";
 import CardsLoader from "../loaders/CardsLoader/CardsLoader";
 import { Context } from "../../context/Context";
 import axios from "axios";
+import { SNEAKERS_URL } from "../../api";
 
 function Cards({
   isCardsLoading,
@@ -20,7 +21,7 @@ function Cards({
   onRemoveFavorite,
 }) {
   const [searchValue, setSearchValue] = useState("");
-  const [isSearched, setIsSearche] = useState(false);
+  const [isSearched, setIsSearched] = useState(false);
   const { setCards, setIsCardsLoading, getSneakersCards } = useContext(Context);
 
   const location = useLocation();
@@ -31,7 +32,7 @@ function Cards({
 
   const onSearchClick = () => {
     axios
-      .get(`http://localhost:3001/sneakers?title_like=${searchValue}`)
+      .get(`${SNEAKERS_URL}?title_like=${searchValue}`)
       .then((res) => {
         setIsCardsLoading(true);
         setCards(res.data);
@@ -39,14 +40,14 @@ function Cards({
       .catch((err) => console.log(err))
       .finally(() => {
         setIsCardsLoading(false);
-        setIsSearche(true);
+        setIsSearched(true);
       });
   };
 
   const onDeleteSearchValue = () => {
     setSearchValue("");
     getSneakersCards();
-    setIsSearche(false);
+    setIsSearched(false);
   };
 
   const onEnter = (event) => {

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -7,8 +7,7 @@ import orderCompleteImg from "../../images/order-compleate.png";
 import { useContext, useState } from "react";
 import { Context } from "../../context/Context";
 import axios from "axios";
-
-const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+import { CART_ITEMS_URL, ORDERS_URL } from "../../api";
 
 function Drawer({
   isDrawerOpen,
@@ -33,21 +32,17 @@ function Drawer({
 
   const onClickOrder = async () => {
     try {
-      const { data } = await axios.post("http://localhost:3001/orders", {
+      const { data } = await axios.post(ORDERS_URL, {
         items: cartItems,
-        totalPrice: totalPrice,
+        totalPrice,
       });
 
-      for (let i = 0; i < cartItems.length; i++) {
-        const item = cartItems[i];
-        await axios.delete("http://localhost:3001/cartItems/" + item.id);
-        await delay(100);
-      }
+      await Promise.all(
+        cartItems.map((item) => axios.delete(`${CART_ITEMS_URL}/${item.id}`))
+      );
 
-      axios
-        .get("http://localhost:3001/orders")
-        .then((res) => setOrders(res.data))
-        .catch((err) => console.log(err));
+      const res = await axios.get(ORDERS_URL);
+      setOrders(res.data);
 
       setOrderId(data.id);
       setIsOrderComplete(true);
@@ -100,7 +95,9 @@ function Drawer({
             </div>
           ) : isCartItemsLoading ? (
             <>
-              {[...Array(3).map((item, index) => <CartLoader key={index} />)]}
+              {[...Array(3)].map((_, index) => (
+                <CartLoader key={index} />
+              ))}
             </>
           ) : (
             cartItems.map((item) => {


### PR DESCRIPTION
## Summary
- centralize API constants in `src/api.js`
- fix typo and search setter in `Cards`
- improve skeleton loader expression in `Drawer`
- fetch/delete orders using Promise.all
- add error handling for API calls

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855de5b5560832fad32311c8dd5459d