### PR TITLE
Add payment support

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -113,6 +113,15 @@ function App() {
     setFavorites(favorites.filter((item) => item.id !== id));
   };
 
+  const payOrder = (id) => {
+    axios
+      .patch(`${ORDERS_URL}/${id}`, { isPaid: true })
+      .then((res) =>
+        setOrders(orders.map((order) => (order.id === id ? res.data : order)))
+      )
+      .catch((err) => console.log(err));
+  };
+
   return (
     <Context.Provider
       value={{
@@ -131,6 +140,7 @@ function App() {
         cartItemsQuantity,
         favoritesQuantity,
         getSneakersCards,
+        payOrder,
       }}
     >
       <div className="app">

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -8,6 +8,9 @@ import { useContext, useState } from "react";
 import { Context } from "../../context/Context";
 import axios from "axios";
 
+const ORDERS_URL = "http://localhost:3001/orders";
+const CART_ITEMS_URL = "http://localhost:3001/cartItems";
+
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function Drawer({
@@ -33,20 +36,20 @@ function Drawer({
 
   const onClickOrder = async () => {
     try {
-      const { data } = await axios.post("http://localhost:3001/orders", {
+      const { data } = await axios.post(ORDERS_URL, {
         items: cartItems,
-        totalPrice: totalPrice,
+        totalPrice,
         isPaid: false,
       });
 
       for (let i = 0; i < cartItems.length; i++) {
         const item = cartItems[i];
-        await axios.delete("http://localhost:3001/cartItems/" + item.id);
+        await axios.delete(`${CART_ITEMS_URL}/${item.id}`);
         await delay(100);
       }
 
       axios
-        .get("http://localhost:3001/orders")
+        .get(ORDERS_URL)
         .then((res) => setOrders(res.data))
         .catch((err) => console.log(err));
 

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -36,6 +36,7 @@ function Drawer({
       const { data } = await axios.post("http://localhost:3001/orders", {
         items: cartItems,
         totalPrice: totalPrice,
+        isPaid: false,
       });
 
       for (let i = 0; i < cartItems.length; i++) {

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -101,7 +101,9 @@ function Drawer({
             </div>
           ) : isCartItemsLoading ? (
             <>
-              {[...Array(3).map((item, index) => <CartLoader key={index} />)]}
+              {[...Array(3)].map((_, index) => (
+                <CartLoader key={index} />
+              ))}
             </>
           ) : (
             cartItems.map((item) => {

--- a/src/pages/Orders/Orders.css
+++ b/src/pages/Orders/Orders.css
@@ -9,3 +9,9 @@
   gap: 40px;
   min-width: 960px;
 }
+
+.order__pay-button {
+  margin-bottom: 20px;
+  width: 200px;
+  align-self: flex-start;
+}

--- a/src/pages/Orders/Orders.js
+++ b/src/pages/Orders/Orders.js
@@ -13,7 +13,7 @@ function Orders({
   onAddToFavorite,
   onRemoveFavorite,
 }) {
-  const { orders, goBack } = useContext(Context);
+  const { orders, goBack, payOrder } = useContext(Context);
   return (
     <section className="cards">
       <div className="cards__top">
@@ -37,6 +37,17 @@ function Orders({
               <div key={item.id} className="order__container">
                 <h2>Заказ №{item.id}</h2>
                 <h3>На сумму: {item.totalPrice} руб.</h3>
+                <p>
+                  Статус: {item.isPaid ? "Оплачен" : "Не оплачен"}
+                </p>
+                {!item.isPaid && (
+                  <button
+                    className="green-button order__pay-button"
+                    onClick={() => payOrder(item.id)}
+                  >
+                    Оплатить
+                  </button>
+                )}
                 <div className="order__items-list">
                   {item.items.map((item) => (
                     <Card

--- a/src/utils/db.json
+++ b/src/utils/db.json
@@ -110,6 +110,7 @@
         }
       ],
       "totalPrice": 30497,
+      "isPaid": false,
       "id": 1
     }
   ]


### PR DESCRIPTION
## Summary
- allow marking orders as paid
- include payment status and button in order list
- send `isPaid` flag in order creation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e0ca8530832f811a2a8e8f322dea