### PR TITLE
Add payment support

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,4 @@
+export const SNEAKERS_URL = "http://localhost:3001/sneakers";
+export const CART_ITEMS_URL = "http://localhost:3001/cartItems";
+export const FAVORITES_URL = "http://localhost:3001/favorites";
+export const ORDERS_URL = "http://localhost:3001/orders";

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -9,6 +9,12 @@ import Orders from "../../pages/Orders/Orders.js";
 import Profile from "../../pages/Profile/Profile.js";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import Favorites from "../../pages/Favorites/Favorites.js";
+import {
+  SNEAKERS_URL,
+  CART_ITEMS_URL,
+  FAVORITES_URL,
+  ORDERS_URL,
+} from "../../api";
 
 function App() {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
@@ -22,10 +28,6 @@ function App() {
   const [isOrdersLoading, setIsOrdersLoading] = useState(true);
   const [isAdded, setIsAdded] = useState(false);
 
-  const SNEAKERS_URL = "http://localhost:3001/sneakers";
-  const CART_ITEMS_URL = "http://localhost:3001/cartItems";
-  const FAVORITES_URL = "http://localhost:3001/favorites";
-  const ORDERS_URL = "http://localhost:3001/orders";
 
   const totalPrice = cartItems.reduce((sum, obj) => obj.price + sum, 0);
   const cartItemsQuantity = cartItems.length;
@@ -86,16 +88,23 @@ function App() {
   };
 
   const onAddToCart = (sneaker) => {
-    const existingCartItem = cartItems.find((item) => item.id === sneaker.id);
+    const existingCartItem = cartItems.find(
+      (item) => item.sneakerId === sneaker.sneakerId
+    );
     if (!existingCartItem) {
-      setCartItems([...cartItems, sneaker]);
-      axios.post(CART_ITEMS_URL, sneaker);
+      axios
+        .post(CART_ITEMS_URL, sneaker)
+        .then((res) => setCartItems([...cartItems, res.data]))
+        .catch((err) => console.log(err));
     }
   };
 
-  const onRemoveItem = (id) => {
-    axios.delete(`${CART_ITEMS_URL}/${id}`);
-    setCartItems(cartItems.filter((item) => item.id !== id));
+  const onRemoveItem = (sneakerId) => {
+    const item = cartItems.find((el) => el.sneakerId === sneakerId);
+    if (item) {
+      axios.delete(`${CART_ITEMS_URL}/${item.id}`);
+      setCartItems(cartItems.filter((el) => el.sneakerId !== sneakerId));
+    }
   };
 
   const onAddToFavorite = (sneaker) => {
@@ -111,6 +120,15 @@ function App() {
   const onRemoveFavorite = (id) => {
     axios.delete(`${FAVORITES_URL}/${id}`);
     setFavorites(favorites.filter((item) => item.id !== id));
+  };
+
+  const payOrder = (id) => {
+    axios
+      .patch(`${ORDERS_URL}/${id}`, { isPaid: true })
+      .then((res) =>
+        setOrders(orders.map((order) => (order.id === id ? res.data : order)))
+      )
+      .catch((err) => console.log(err));
   };
 
   return (
@@ -131,6 +149,7 @@ function App() {
         cartItemsQuantity,
         favoritesQuantity,
         getSneakersCards,
+        payOrder,
       }}
     >
       <div className="app">

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -21,7 +21,7 @@ function Card({
 
   useEffect(() => {
     // Проверяем, есть ли текущая карточка в корзине
-    const isInCart = cartItems.some((item) => item.id === id);
+    const isInCart = cartItems.some((item) => item.sneakerId === id);
     setIsAdded(isInCart);
   }, [cartItems, id]);
 
@@ -33,7 +33,7 @@ function Card({
 
   const handleAddCardClick = () => {
     setIsAdded(!isAdded);
-    onAddToCart({ id, imageUrl, title, price });
+    onAddToCart({ sneakerId: id, imageUrl, title, price });
   };
 
   const handleDeleteCardClick = (id) => {

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -7,6 +7,7 @@ import orderCompleteImg from "../../images/order-compleate.png";
 import { useContext, useState } from "react";
 import { Context } from "../../context/Context";
 import axios from "axios";
+import { CART_ITEMS_URL, ORDERS_URL } from "../../api";
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -26,26 +27,27 @@ function Drawer({
     setIsOrderComplete(false);
   };
 
-  const handleDeleteCardClick = (id) => {
-    onRemove(id);
-    setCartItems(cartItems.filter((item) => item.id !== id));
+  const handleDeleteCardClick = (sneakerId) => {
+    onRemove(sneakerId);
+    setCartItems(cartItems.filter((item) => item.sneakerId !== sneakerId));
   };
 
   const onClickOrder = async () => {
     try {
-      const { data } = await axios.post("http://localhost:3001/orders", {
+      const { data } = await axios.post(ORDERS_URL, {
         items: cartItems,
-        totalPrice: totalPrice,
+        totalPrice,
+        isPaid: false,
       });
 
       for (let i = 0; i < cartItems.length; i++) {
         const item = cartItems[i];
-        await axios.delete("http://localhost:3001/cartItems/" + item.id);
+        await axios.delete(`${CART_ITEMS_URL}/${item.id}`);
         await delay(100);
       }
 
       axios
-        .get("http://localhost:3001/orders")
+        .get(ORDERS_URL)
         .then((res) => setOrders(res.data))
         .catch((err) => console.log(err));
 
@@ -100,7 +102,9 @@ function Drawer({
             </div>
           ) : isCartItemsLoading ? (
             <>
-              {[...Array(3).map((item, index) => <CartLoader key={index} />)]}
+              {[...Array(3)].map((_, index) => (
+                <CartLoader key={index} />
+              ))}
             </>
           ) : (
             cartItems.map((item) => {
@@ -123,7 +127,7 @@ function Drawer({
                     className="remove-button"
                     src={closeBtn}
                     alt="Remove"
-                    onClick={() => handleDeleteCardClick(item.id)}
+                    onClick={() => handleDeleteCardClick(item.sneakerId)}
                   />
                 </div>
               );

--- a/src/pages/Orders/Orders.css
+++ b/src/pages/Orders/Orders.css
@@ -9,3 +9,9 @@
   gap: 40px;
   min-width: 960px;
 }
+
+.order__pay-button {
+  margin-bottom: 20px;
+  width: 200px;
+  align-self: flex-start;
+}

--- a/src/pages/Orders/Orders.js
+++ b/src/pages/Orders/Orders.js
@@ -13,7 +13,7 @@ function Orders({
   onAddToFavorite,
   onRemoveFavorite,
 }) {
-  const { orders, goBack } = useContext(Context);
+  const { orders, goBack, payOrder } = useContext(Context);
   return (
     <section className="cards">
       <div className="cards__top">
@@ -37,11 +37,25 @@ function Orders({
               <div key={item.id} className="order__container">
                 <h2>Заказ №{item.id}</h2>
                 <h3>На сумму: {item.totalPrice} руб.</h3>
+                <p>
+                  Статус: {item.isPaid ? "Оплачен" : "Не оплачен"}
+                </p>
+                {!item.isPaid && (
+                  <button
+                    className="green-button order__pay-button"
+                    onClick={() => payOrder(item.id)}
+                  >
+                    Оплатить
+                  </button>
+                )}
                 <div className="order__items-list">
                   {item.items.map((item) => (
                     <Card
                       key={item.id}
-                      {...item}
+                      id={item.sneakerId || item.id}
+                      imageUrl={item.imageUrl}
+                      title={item.title}
+                      price={item.price}
                       onAddToCart={onAddToCart}
                       onAddToFavorite={onAddToFavorite}
                       onRemoveFavorite={onRemoveFavorite}

--- a/src/utils/db.json
+++ b/src/utils/db.json
@@ -91,25 +91,29 @@
     {
       "items": [
         {
-          "id": "2",
+          "id": 1,
+          "sneakerId": 2,
           "imageUrl": "https://i.postimg.cc/c1zb2tnn/sneakers-2.jpg",
           "title": "Мужские Кроссовки Nike Air Max 270",
           "price": 12999
         },
         {
-          "id": "3",
+          "id": 2,
+          "sneakerId": 3,
           "imageUrl": "https://i.postimg.cc/BbR7KR0g/sneakers-3.jpg",
           "title": "Мужские Кроссовки Nike Blazer Mid Suede",
           "price": 8499
         },
         {
-          "id": "4",
+          "id": 3,
+          "sneakerId": 4,
           "imageUrl": "https://i.postimg.cc/bwxVZ6Fx/sneakers-4.jpg",
           "title": "Кроссовки Puma X Aka Boku Future Rider",
           "price": 8999
         }
       ],
       "totalPrice": 30497,
+      "isPaid": false,
       "id": 1
     }
   ]


### PR DESCRIPTION
## Summary
- allow marking orders as paid
- include payment status and button in order list
- send `isPaid` flag in order creation
- fix placeholder rendering while loading cart
- refactor Drawer order creation
- centralize API endpoints for reuse
- use server-generated cart IDs to avoid deletion errors

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e0ca8530832f811a2a8e8f322dea